### PR TITLE
Eliminate error by hugo

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -11,9 +11,9 @@
           {{ $inScope := ( $currentNode.HasMenuCurrent "global" . ) }}
           <li>
             {{ if or $atTopLevel $inScope }}
-              <a href="{{ .Url }}" class="site-link is-active">{{ .Name }}</a>
+              <a href="{{ .URL }}" class="site-link is-active">{{ .Name }}</a>
             {{ else }}
-              <a href="{{ .Url }}" class="site-link">{{ .Name }}</a>
+              <a href="{{ .URL }}" class="site-link">{{ .Name }}</a>
             {{ end }}
           </li>
         {{ end }}

--- a/layouts/partials/meta.html
+++ b/layouts/partials/meta.html
@@ -1,10 +1,10 @@
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width">
-{{ if eq .Url "/" }}
+{{ if eq .URL "/" }}
   <title>{{ .Site.Title }}</title>
-{{ else if eq .Url "/blog/" }}
+{{ else if eq .URL "/blog/" }}
   <title>Blog - {{ .Site.Title }}</title>
-{{ else if eq .Url "/work/" }}
+{{ else if eq .URL "/work/" }}
   <title>Work - {{ .Site.Title }}</title>
 {{ else if eq .Slug "about" }}
   <title>About - {{ .Site.Title }}</title>

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -2,7 +2,7 @@
 {{ if gt $pag.TotalPages 1 }}
   <ul class="pagination pagination-with-pages">
     <li class="pagination-prev{{ if not $pag.HasPrev }} disabled{{ end }}">
-      <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.Url }}{{ end }}" aria-label="Previous">
+      <a href="{{ if $pag.HasPrev }}{{ $pag.Prev.URL }}{{ end }}" aria-label="Previous">
         <span aria-hidden="true">
           <i class="icon ico-arrow-prev pagination-prev-icon"></i>Prev
         </span>
@@ -15,12 +15,12 @@
         </li>
       {{ else }}
         <li>
-          <a href="{{ .Url }}">{{ .PageNumber }}</a>
+          <a href="{{ .URL }}">{{ .PageNumber }}</a>
         </li>
       {{ end }}
     {{ end }}
     <li class="pagination-next{{ if not $pag.HasNext }} disabled{{ end }}">
-      <a href="{{ if $pag.HasNext }}{{ $pag.Next.Url }}{{ end }}" aria-label="Next">
+      <a href="{{ if $pag.HasNext }}{{ $pag.Next.URL }}{{ end }}" aria-label="Next">
         <span aria-hidden="true">
           Next<i class="icon ico-arrow-next pagination-next-icon"></i>
         </span>


### PR DESCRIPTION
```
$ hugo server -w                                                                                                                                          (rbenv:2.1.4)
ERROR: 2015/06/24 Node's .Url is deprecated and will be removed in Hugo 0.15. Use .URL instead.
ERROR: 2015/06/24 MenuEntry's .Url is deprecated and will be removed in Hugo 0.15. Use .URL instead.
ERROR: 2015/06/24 Paginator's .Url is deprecated and will be removed in Hugo 0.15. Use .URL instead.
...
```
